### PR TITLE
Refactor MockS3 example

### DIFF
--- a/mockS3/myservice.go
+++ b/mockS3/myservice.go
@@ -8,10 +8,15 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
+// Myservice is an example serice that uses an s3Client
+type Myservice struct {
+	S3Client s3iface.S3API
+}
+
 // GetObjectAsString returns the content of an s3 object as a string
 // it is important here that the s3Client is of type s3iface.S3API
-func GetObjectAsString(s3Client s3iface.S3API, key string) (string, error) {
-	out, err := s3Client.GetObject(&s3.GetObjectInput{
+func (m *Myservice) GetObjectAsString(key string) (string, error) {
+	out, err := m.S3Client.GetObject(&s3.GetObjectInput{
 		Key: aws.String(key),
 	})
 	if err != nil {

--- a/mockS3/myservice_test.go
+++ b/mockS3/myservice_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+
 	"github.com/kristaxox/go-examples/mockS3"
 )
 
@@ -32,7 +33,7 @@ func (m mockS3Impl) GetObject(input *s3.GetObjectInput) (*s3.GetObjectOutput, er
 	}, nil
 }
 
-// Since the mockS3 struct implements the required s3 api calls that our client
+// Since the mockS3Impl struct implements the required s3 api calls that our client
 // need to make AND is of type s3iface, in our code that actually calls s3 we can
 // the s3iface type instead of s3.S3, and mock out s3 call right in our tests.
 // The input and output contents can be customizes to suit the amount of fileds
@@ -44,7 +45,11 @@ func TestGetObject(t *testing.T) {
 
 	mock.InMemoryStore["foo"] = "bar"
 
-	str, err := mockS3.GetObjectAsString(mock, "foo")
+	myservice := mockS3.Myservice{
+		S3Client: mock,
+	}
+
+	str, err := myservice.GetObjectAsString("foo")
 	if err != nil {
 		t.Fail()
 	}


### PR DESCRIPTION
 - refactor into an actual client to better show how you can use the `s3iface.S3API`.